### PR TITLE
fix: count_rows incorrect with filter

### DIFF
--- a/lance_ray/datasource.py
+++ b/lance_ray/datasource.py
@@ -77,8 +77,15 @@ class LanceDatasource(Datasource):
             if len(fragments) == 0:
                 continue
 
+            # Use scanner.count_rows with filter to count rows meeting specified conditions
+            scanner_options = self._scanner_options.copy()
+            scanner_options["fragments"] = fragments
+            scanner_options["columns"] = []
+            scanner_options["with_row_id"] = True
+            scanner = self._lance_ds.scanner(**scanner_options)
+            num_rows = scanner.count_rows()
+
             fragment_ids = [f.metadata.id for f in fragments]
-            num_rows = sum(f.count_rows() for f in fragments)
             input_files = [
                 data_file.path 
                 for fragment in fragments 

--- a/tests/test_basic_read_write.py
+++ b/tests/test_basic_read_write.py
@@ -134,6 +134,13 @@ class TestReadLance:
         assert len(df) == 3
         assert all(df["age"] >= 35)
 
+    def test_read_lance_filter_and_count(self, lance_dataset_path):
+        """Test reading filter and count."""
+        dataset = lr.read_lance(
+            lance_dataset_path, columns=["name", "age"], filter="age >= 35"
+        )
+        assert dataset.count() == 3
+
     def test_read_lance_nonexistent_path(self):
         """Test reading from non-existent path."""
         with pytest.raises((FileNotFoundError, OSError, Exception)):


### PR DESCRIPTION
closes https://github.com/lancedb/lance-ray/issues/15

We've identified that the count operation with filters returns incorrect results in the current Lance connector implementation. 

This issue has previously been addressed in our https://github.com/ray-project/ray/pull/53162 by @Jay-ju. We'll be migrating the fix to this project to ensure:
1. Correct count results with various filter conditions
2. Proper handling of edge cases observed in our production workloads


