### PR TITLE
feat: support lance-ray distributed fts indexing building

### DIFF
--- a/docs/src/.pages
+++ b/docs/src/.pages
@@ -1,6 +1,8 @@
+
 nav:
   - Welcome: index.md
   - Read: read.md
   - Write: write.md
+  - Index: distributed-indexing.md
   - Data Evolution: data-evolution.md
   - Examples: examples.md

--- a/docs/src/distributed-indexing.md
+++ b/docs/src/distributed-indexing.md
@@ -1,0 +1,111 @@
+
+# Distributed Index Building
+
+Lance-Ray provides distributed index building functionality that leverages Ray's distributed computing capabilities to efficiently create text indices for Lance datasets. This is particularly useful for large-scale datasets as it can distribute index building work across multiple Ray worker nodes.
+
+## New Distributed APIs
+
+`create_scalar_index()` - Distributedly create scalar index index using ray. Currently only Inverted/FTS are supported. Will add more index type support in the future.
+
+### How It Works
+The `create_scalar_index` function allows you to create full-text search indices for Lance datasets using the Ray distributed computing framework. This function distributes the index building process across multiple Ray worker nodes, with each node responsible for building indices for a subset of dataset fragments. These indices are then merged and committed as a single index.
+
+**Backward Compatibility**:
+   - Automatically detect availability of new APIs across different Lance versions
+   - Gracefully fallback to raise tips when new APIs are unavailable
+
+
+**`create_scalar_index`**
+
+```python
+def create_scalar_index(
+    dataset: Union[str, "lance.LanceDataset"],
+    column: str,
+    index_type: str,
+    name: Optional[str] = None,
+    num_workers: int = 4,
+    storage_options: Optional[dict[str, str]] = None,
+    ray_remote_args: Optional[dict[str, Any]] = None,
+    **kwargs: Any,
+) -> "lance.LanceDataset":
+
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `dataset` | `str` or `lance.LanceDataset` | Lance dataset or its URI |
+| `column` | `str` | Column name to index |
+| `index_type` | `str` | Index type, can be `"INVERTED"` or `"FTS"` |
+| `name` | `str`, optional | Index name, auto-generated if not provided |
+| `num_workers` | `int`, optional | Number of Ray worker nodes to use, default is 4 |
+| `storage_options` | `Dict[str, str]`, optional | Storage options for the dataset |
+| `ray_remote_args` | `Dict[str, Any]`, optional | Ray task options (e.g., `num_cpus`, `resources`) |
+| `**kwargs` | `Any` | Additional arguments passed to `create_scalar_index` |
+
+### Return Value
+
+The function returns an updated Lance dataset with the newly created index.
+
+
+## Examples
+
+### Basic Usage
+
+```python
+import lance
+import lance_ray as lr
+
+# Create or load Lance dataset
+dataset = lance.dataset("path/to/dataset")
+
+# Build distributed index
+updated_dataset = lr.create_scalar_index(
+   dataset=dataset,
+   column="text",
+   index_type="INVERTED",
+   num_workers=4
+)
+
+# Verify index creation
+indices = updated_dataset.list_indices()
+print(f"Index list: {indices}")
+
+# Use index for search
+results = updated_dataset.scanner(
+   full_text_query="search term",
+   columns=["id", "text"]
+).to_table()
+print(f"Search results: {results}")
+```
+
+### Custom Index Name
+
+```python
+updated_dataset = lr.create_scalar_index(
+   dataset="path/to/dataset",
+   column="text",
+   index_type="INVERTED",
+   name="custom_text_index",
+   num_workers=4
+)
+```
+
+### Custom Ray Options
+
+```python
+updated_dataset = lr.create_scalar_index(
+   dataset="path/to/dataset",
+   column="text",
+   index_type="INVERTED",
+   num_workers=4,
+   ray_remote_args={"num_cpus": 2, "resources": {"custom_resource": 1}}
+)
+```
+
+### Performance Considerations
+
+- For very large datasets, it's recommended to use more powerful CPU/memory ray worker nodes. Increasing `num_workers` can improve index building speed, but requires more computational nodes.
+- Too many num_workers can cause large number of partitions, which cause FTS queries slowness as lots of index partitions need to be loaded when searching.
+- If `num_workers` is greater than the number of fragments, it will be automatically adjusted to match the fragment count

--- a/examples/distribute_fts_index.py
+++ b/examples/distribute_fts_index.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+Demonstration of distributed text indexing with PR #4578 enhancements.
+This example shows how to use the enhanced distributed text indexing functionality
+that leverages the new API
+
+Requirements:
+- ray
+- lance_ray
+- lance (with PR #4578 changes)
+"""
+
+import logging
+import tempfile
+from pathlib import Path
+
+import lance
+import lance_ray as lr
+import pandas as pd
+import ray
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def generate_sample_dataset(num_fragments=4, rows_per_fragment=1000):
+    """Generate a sample dataset with multiple fragments for testing."""
+    logger.info(f"Generating dataset with {num_fragments} fragments, {rows_per_fragment} rows each")
+
+    all_data = []
+    for frag_idx in range(num_fragments):
+        for row_idx in range(rows_per_fragment):
+            row_id = frag_idx * rows_per_fragment + row_idx
+            all_data.append({
+                "id": row_id,
+                "title": f"Document {row_id}: Sample Title for Fragment {frag_idx}",
+                "content": f"This is the content of document {row_id}. "
+                          f"It contains sample text for testing distributed indexing functionality. "
+                          f"Fragment ID: {frag_idx}. Keywords: distributed, indexing, lance, ray, search.",
+                "category": ["technology", "database", "search", "distributed"][frag_idx % 4],
+                "fragment_id": frag_idx,
+            })
+
+    return pd.DataFrame(all_data)
+
+
+def create_multi_fragment_dataset(data_df, output_path, max_rows_per_file):
+    """Create a Lance dataset with multiple fragments."""
+    logger.info(f"Creating Lance dataset at {output_path}")
+
+    # Convert to Ray dataset
+    ray_dataset = ray.data.from_pandas(data_df)
+
+    # Write as Lance dataset with multiple fragments
+    lr.write_lance(ray_dataset, output_path, max_rows_per_file=max_rows_per_file)
+
+    # Load and return Lance dataset
+    dataset = lance.dataset(output_path)
+    logger.info(f"Created dataset with {len(dataset.get_fragments())} fragments")
+
+    return dataset
+
+
+def demonstrate_new_api_features(dataset, column="content"):
+    """Demonstrate the new distributed indexing API features from PR #4578."""
+    logger.info("=== Demonstrating New API Features (PR #4578) ===")
+
+    try:
+        # Build distributed index using the enhanced API
+        logger.info("Building distributed index with new API features...")
+
+        updated_dataset = lr.create_scalar_index(
+            dataset=dataset,
+            column=column,
+            index_type="INVERTED",
+            name="pr4578_enhanced_idx",
+            num_workers=4,
+            remove_stop_words=False,
+            with_position=True,  # Enable phrase queries
+        )
+
+        logger.info("✅ Successfully created distributed index with new API")
+
+        # Verify index creation
+        indices = updated_dataset.list_indices()
+        logger.info(f"Total indices: {len(indices)}")
+
+        for idx in indices:
+            if idx["name"] == "pr4578_enhanced_idx":
+                logger.info(f"✅ Found our index: {idx['name']} (type: {idx['type']})")
+                break
+        else:
+            logger.warning("❌ Our index not found in the list")
+
+        return updated_dataset
+
+    except Exception as e:
+        logger.error(f"❌ Error with new API: {e}")
+        logger.info("This is expected if PR #4578 changes are not available")
+        return None
+
+
+def demonstrate_search_functionality(dataset, search_queries=None):
+    """Demonstrate search functionality with the created index."""
+    logger.info("=== Demonstrating Search Functionality ===")
+
+    if search_queries is None:
+        search_queries = [
+            "distributed indexing",
+            "lance ray",
+            "sample text",
+            "technology database",
+        ]
+
+    for query in search_queries:
+        try:
+            logger.info(f"Searching for: '{query}'")
+
+            results = dataset.scanner(
+                full_text_query=query,
+                columns=["id", "title", "content", "category"],
+            ).to_table()
+
+            logger.info(f"  Found {results.num_rows} results")
+
+            if results.num_rows > 0:
+                # Show top 3 results
+                for i in range(min(3, results.num_rows)):
+                    title = results.column("title")[i].as_py()
+                    category = results.column("category")[i].as_py()
+                    logger.info(f"  [{i+1}] {title} (Category: {category})")
+
+        except Exception as e:
+            logger.error(f"❌ Search failed for '{query}': {e}")
+
+
+
+
+
+def main():
+    """Main demonstration function."""
+    logger.info("🚀 Starting Distributed Text Indexing Demo (PR #4578)")
+
+    # Initialize Ray
+    if not ray.is_initialized():
+        ray.init(local_mode=False, ignore_reinit_error=True)
+        logger.info("✅ Ray initialized")
+
+    try:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Generate sample data
+            data_df = generate_sample_dataset(num_fragments=4, rows_per_fragment=500)
+
+            # Create multi-fragment dataset
+            dataset_path = Path(temp_dir) / "pr4578_demo_dataset.lance"
+            dataset = create_multi_fragment_dataset(
+                data_df, str(dataset_path), max_rows_per_file=500
+            )
+
+            logger.info(f"Dataset created with {len(dataset.get_fragments())} fragments")
+
+            # Demonstrate new API features
+            enhanced_dataset = demonstrate_new_api_features(dataset)
+
+            if enhanced_dataset:
+                # Test search functionality with new API
+                demonstrate_search_functionality(enhanced_dataset)
+                logger.info("🎉 Demo completed successfully!")
+            else:
+                logger.error("❌ New API features not available - PR #4578 may not be merged")
+
+    except Exception as e:
+        logger.error(f"❌ Demo failed: {e}")
+        raise
+
+    finally:
+        # Clean up Ray
+        if ray.is_initialized():
+            ray.shutdown()
+            logger.info("✅ Ray shutdown")
+
+
+if __name__ == "__main__":
+    main()

--- a/lance_ray/__init__.py
+++ b/lance_ray/__init__.py
@@ -10,10 +10,12 @@ __author__ = "LanceDB Devs"
 __email__ = "dev@lancedb.com"
 
 # Main imports
+from .index import create_scalar_index
 from .io import add_columns, read_lance, write_lance
 
 __all__ = [
     "read_lance",
     "write_lance",
     "add_columns",
+    "create_scalar_index",
 ]

--- a/lance_ray/index.py
+++ b/lance_ray/index.py
@@ -1,0 +1,442 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+import logging
+import re
+import time
+import uuid
+from typing import Any, Optional, Union
+
+import lance
+import pyarrow as pa
+from lance.dataset import Index, LanceDataset
+from packaging import version
+from ray.util.multiprocessing import Pool
+
+logger = logging.getLogger(__name__)
+
+def _distribute_fragments_balanced(
+    fragments: list[Any], num_workers: int, logger: logging.Logger
+) -> list[list[int]]:
+    """
+    Distribute fragments across workers using a balanced algorithm that considers fragment sizes.
+
+    This function implements a greedy algorithm that assigns fragments to the worker
+    with the currently smallest total workload, helping to balance the processing
+    time across workers.
+
+    Args:
+        fragments: List of Lance fragment objects
+        num_workers: Number of workers to distribute fragments across
+        logger: Logger instance for debugging information
+
+    Returns:
+        List of lists, where each inner list contains fragment IDs for one worker
+    """
+    if not fragments:
+        return [[] for _ in range(num_workers)]
+
+    # Get fragment information (ID and size)
+    fragment_info = []
+    for fragment in fragments:
+        try:
+            # Try to get fragment size information
+            # fragment.count_rows() gives us the number of rows in the fragment
+            row_count = fragment.count_rows()
+            fragment_info.append({
+                "id": fragment.fragment_id,
+                "size": row_count,
+            })
+        except Exception as e:
+            # If we can't get size info, use fragment_id as a fallback
+            logger.warning(
+                f"Could not get size for fragment {fragment.fragment_id}: {e}. "
+                "Using fragment_id as size estimate."
+            )
+            fragment_info.append({
+                "id": fragment.fragment_id,
+                "size": fragment.fragment_id,  # Fallback to fragment_id
+            })
+
+    # Sort fragments by size in descending order (largest first)
+    # This helps with better load balancing using the greedy algorithm
+    fragment_info.sort(key=lambda x: x["size"], reverse=True)
+
+    # Initialize worker batches and their current workloads
+    worker_batches = [[] for _ in range(num_workers)]
+    worker_workloads = [0] * num_workers
+
+    # Greedy assignment: assign each fragment to the worker with minimum workload
+    for frag_info in fragment_info:
+        # Find the worker with the minimum current workload
+        min_workload_idx = min(range(num_workers), key=lambda i: worker_workloads[i])
+
+        # Assign fragment to this worker
+        worker_batches[min_workload_idx].append(frag_info["id"])
+        worker_workloads[min_workload_idx] += frag_info["size"]
+
+    # Log distribution statistics for debugging
+    total_size = sum(frag_info["size"] for frag_info in fragment_info)
+    logger.info("Fragment distribution statistics:")
+    logger.info(f"  Total fragments: {len(fragment_info)}")
+    logger.info(f"  Total size: {total_size}")
+    logger.info(f"  Workers: {num_workers}")
+
+    for i, (batch, workload) in enumerate(zip(worker_batches, worker_workloads, strict=False)):
+        percentage = (workload / total_size * 100) if total_size > 0 else 0
+        logger.info(
+            f"  Worker {i}: {len(batch)} fragments, "
+            f"workload: {workload} ({percentage:.1f}%)"
+        )
+
+    # Filter out empty batches (shouldn't happen with proper input validation)
+    non_empty_batches = [batch for batch in worker_batches if batch]
+
+    return non_empty_batches
+
+
+def generate_default_index_name(column: str, index_type: str, dataset: Optional["lance.LanceDataset"] = None) -> str:
+    """
+    Generate a default index name based on column name and index type
+
+    Args:
+        column: The column name to base the index name on
+        index_type: The type of index (e.g., "INVERTED", "FTS")
+        dataset: Optional Lance dataset to check for existing indices
+
+    Returns:
+        A unique, valid index name
+    """
+    # Normalize the column name
+    if not column:
+        normalized_column = "column"
+    else:
+        # Replace invalid chars with underscores
+        normalized = re.sub(r"[^a-zA-Z0-9_]", "_", column)
+
+        # Collapse multiple underscores
+        normalized = re.sub(r"_+", "_", normalized)
+
+        # Remove leading and trailing underscores
+        normalized = normalized.strip("_")
+
+        # If empty after normalization or starts with a number, use default
+        if not normalized or normalized[0].isdigit():
+            normalized_column = "column"
+        else:
+            normalized_column = normalized
+
+    # Normalize index type
+    normalized_index_type = index_type.lower()
+
+    # Build the base name
+    base_name = f"{normalized_column}_{normalized_index_type}_idx"
+
+    # Check for conflicts if dataset is provided
+    if dataset is not None:
+        try:
+            existing_indices = dataset.list_indices()
+            existing_names = {idx["name"] for idx in existing_indices}
+
+            if base_name in existing_names:
+                # Find the next available suffix number
+                for i in range(2, 1000):
+                    candidate = f"{base_name}_{i}"
+                    if candidate not in existing_names:
+                        return candidate
+
+                # Use timestamp suffix if all numbered options are taken
+                return f"{base_name}_{int(time.time())}"
+        except Exception:
+            # If we can't check existing indices, just return the base name
+            pass
+
+    return base_name
+
+
+def _handle_fragment_index(
+    dataset_uri: str,
+    column: str,
+    index_type: str,
+    name: str,
+    fragment_uuid: str,
+    storage_options: Optional[dict[str, str]] = None,
+    **kwargs: Any,
+):
+    """
+    Create a function to handle fragment index building for use with Pool.
+    This function returns a callable that can be used with Pool.map_async
+    to build indices for specific fragments.
+    """
+    def func(fragment_ids: list[int]) -> dict[str, Any]:
+        """
+        Handle fragment index building using the distributed API.
+
+        This function calls create_scalar_index directly for specific fragments.
+        After execution, fragment-level indices are automatically built.
+
+        Args:
+            fragment_ids: List of fragment IDs to build index for
+
+        Returns:
+            Dictionary with status and result information
+        """
+        try:
+            # Basic input validation
+            if not fragment_ids:
+                raise ValueError("fragment_ids cannot be empty")
+
+            # Validate fragment_id ranges
+            for fragment_id in fragment_ids:
+                if fragment_id < 0 or fragment_id > 0xFFFFFFFF:
+                    raise ValueError(f"Invalid fragment_id: {fragment_id}")
+
+            # Load dataset
+            dataset = LanceDataset(dataset_uri, storage_options=storage_options)
+
+            # Validate fragments exist
+            available_fragments = {f.fragment_id for f in dataset.get_fragments()}
+            invalid_fragments = set(fragment_ids) - available_fragments
+            if invalid_fragments:
+                raise ValueError(f"Fragment IDs {invalid_fragments} do not exist")
+
+            # Use the distributed index building API - Phase 1: Fragment index creation
+            logger.info(f"Building distributed index for fragments {fragment_ids} using create_scalar_index")
+
+            # Call create_scalar_index directly - no return value expected
+            # After execution, fragment-level indices are automatically built
+            dataset.create_scalar_index(
+                column=column,
+                index_type=index_type,
+                name=name,
+                replace=False,
+                fragment_uuid=fragment_uuid,
+                fragment_ids=fragment_ids,
+                **kwargs
+            )
+
+            # Get field ID for the indexed column
+            field_id = dataset.schema.get_field_index(column)
+
+            logger.info(f"Fragment index created successfully for fragments {fragment_ids}")
+
+            return {
+                "status": "success",
+                "fragment_ids": fragment_ids,
+                "fields": [field_id],
+                "uuid": fragment_uuid,
+            }
+
+        except Exception as e:
+            logger.error(f"Fragment index task failed for fragments {fragment_ids}: {e}")
+            return {
+                "status": "error",
+                "fragment_ids": fragment_ids,
+                "error": str(e),
+            }
+
+    return func
+
+def merge_index_metadata_compat(dataset, index_id, default_index_type="INVERTED"):
+    try:
+        return dataset.merge_index_metadata(index_id, default_index_type)
+    except TypeError:
+        return dataset.merge_index_metadata(index_id)
+
+def create_scalar_index(
+    dataset: Union[str, "lance.LanceDataset"],
+    column: str,
+    index_type: str,
+    name: Optional[str] = None,
+    num_workers: int = 4,
+    storage_options: Optional[dict[str, str]] = None,
+    ray_remote_args: Optional[dict[str, Any]] = None,
+    **kwargs: Any,
+) -> "lance.LanceDataset":
+    """
+    Build a distributed full-text search index using Ray.
+
+    This function distributes the index building process across multiple Ray workers,
+    with each worker building indices for a subset of fragments. The indices are then
+    merged and committed as a single index.
+
+    Args:
+        dataset: Lance dataset or URI to build index on
+        column: Column name to index
+        index_type: Type of index to build ("INVERTED" or "FTS")
+        name: Name of the index (generated if None)
+        num_workers: Number of Ray workers to use
+        storage_options: Storage options for the dataset
+        ray_remote_args: Options for Ray tasks (e.g., num_cpus, resources)
+        **kwargs: Additional arguments to pass to create_scalar_index
+
+    Returns:
+        Updated Lance dataset with the index created
+
+    Raises:
+        ValueError: If input parameters are invalid
+        TypeError: If column type is not string
+        RuntimeError: If index building fails or pylance version is incompatible
+    """
+    # Check pylance version compatibility
+    try:
+        lance_version = version.parse(lance.__version__)
+        min_required_version = version.parse("0.36.0")
+
+        if lance_version < min_required_version:
+            raise RuntimeError(
+                f"Distributed indexing requires pylance >= 0.36.0, but found {lance.__version__}. "
+                "The distribute-related interfaces are not available in older versions. "
+                "Please upgrade pylance by running: pip install --upgrade pylance"
+            )
+
+        logger.info(f"Pylance version check passed: {lance.__version__} >= 0.36.0")
+
+    except AttributeError as err:
+        # If lance.__version__ doesn't exist, assume it's too old
+        raise RuntimeError(
+            "Cannot determine pylance version. Distributed indexing requires pylance >= 0.36.0. "
+            "Please upgrade pylance by running: pip install --upgrade pylance"
+        ) from err
+
+    index_id = str(uuid.uuid4())
+    logger.info(f"Starting distributed index build with ID: {index_id}")
+
+    # Basic input validation
+    if not column:
+        raise ValueError("Column name cannot be empty")
+
+    if num_workers <= 0:
+        raise ValueError(f"num_workers must be positive, got {num_workers}")
+
+    if index_type not in ["INVERTED", "FTS"]:
+        raise ValueError(f"Index type must be 'INVERTED' or 'FTS', not '{index_type}'")
+
+    # Note: Ray initialization is now handled by the Pool, following the pattern from io.py
+    # This removes the need for explicit ray.init() calls
+
+    # Load dataset
+    if isinstance(dataset, str):
+        dataset_uri = dataset
+        dataset = LanceDataset(dataset_uri, storage_options=storage_options)
+    else:
+        dataset_uri = dataset.uri
+
+    # Validate column exists and has correct type
+    try:
+        field = dataset.schema.field(column)
+    except KeyError as e:
+        available_columns = [field.name for field in dataset.schema]
+        raise ValueError(f"Column '{column}' not found. Available: {available_columns}") from e
+
+    if storage_options is None:
+        storage_options = dataset._storage_options
+
+    # Check column type
+    value_type = field.type
+    if pa.types.is_list(field.type) or pa.types.is_large_list(field.type):
+        value_type = field.type.value_type
+
+    if not pa.types.is_string(value_type) and not pa.types.is_large_string(value_type):
+        raise TypeError(f"Column {column} must be string type, got {value_type}")
+
+    if name is None:
+        name = generate_default_index_name(column, index_type, dataset)
+
+    # Get fragments
+    fragments = dataset.get_fragments()
+    if not fragments:
+        raise ValueError("Dataset contains no fragments")
+
+    fragment_ids = [fragment.fragment_id for fragment in fragments]
+
+    # Adjust num_workers if needed
+    if num_workers > len(fragment_ids):
+        num_workers = len(fragment_ids)
+        logger.info(f"Adjusted num_workers to {num_workers} to match fragment count")
+
+    # Distribute fragments to workers using balanced distribution algorithm
+    fragment_batches = _distribute_fragments_balanced(
+        fragments, num_workers, logger
+    )
+
+    # Phase 1: Fragment index creation using Pool pattern (similar to io.py)
+    # Use Pool to distribute work instead of direct Ray task submission
+    pool = Pool(processes=num_workers, ray_remote_args=ray_remote_args)
+
+    # Create the fragment handler function
+    fragment_handler = _handle_fragment_index(
+        dataset_uri=dataset_uri,
+        column=column,
+        index_type=index_type,
+        name=name,
+        fragment_uuid=index_id,
+        storage_options=storage_options,
+        **kwargs,
+    )
+
+    # Submit tasks using Pool.map_async
+    rst_futures = pool.map_async(
+        fragment_handler,
+        fragment_batches,
+        chunksize=1,
+    )
+
+    # Wait for results
+    try:
+        results = rst_futures.get()
+    except Exception as e:
+        pool.close()
+        raise RuntimeError(f"Failed to complete distributed index building: {e}") from e
+    finally:
+        pool.close()
+
+    # Check for failures
+    failed_results = [r for r in results if r["status"] == "error"]
+    if failed_results:
+        error_messages = [r["error"] for r in failed_results]
+        raise RuntimeError(f"Index building failed: {'; '.join(error_messages)}")
+
+    # Reload dataset to get the latest state after fragment index creation
+    dataset = LanceDataset(dataset_uri, storage_options=storage_options)
+
+    # Phase 2: Merge index metadata using the distributed API
+    logger.info(f"Phase 2: Merging index metadata for index ID: {index_id}")
+    merge_index_metadata_compat(dataset, index_id)
+
+    # Phase 3: Create Index object and commit the operation
+    logger.info(f"Phase 3: Creating and committing index '{name}'")
+
+    # Get field information from successful results
+    successful_results = [r for r in results if r["status"] == "success"]
+    if not successful_results:
+        raise RuntimeError("No successful index creation results found")
+
+    fields = successful_results[0]["fields"]
+
+    # Create Index object
+    index = Index(
+        uuid=index_id,
+        name=name,
+        fields=fields,
+        dataset_version=dataset.version,
+        fragment_ids=set(fragment_ids),
+        index_version=0,
+    )
+
+    # Create and commit the index operation
+    create_index_op = lance.LanceOperation.CreateIndex(
+        new_indices=[index],
+        removed_indices=[],
+    )
+
+    updated_dataset = lance.LanceDataset.commit(
+        dataset_uri,
+        create_index_op,
+        read_version=dataset.version,
+        storage_options=storage_options,
+    )
+
+    logger.info(f"Successfully created distributed index '{name}' with three-phase workflow")
+    logger.info(f"Index ID: {index_id}, Fragments: {len(fragment_ids)}, Workers: {len(fragment_batches)}")
+    return updated_dataset

--- a/tests/test_distributed_indexing.py
+++ b/tests/test_distributed_indexing.py
@@ -1,0 +1,552 @@
+"""Test cases for lance_ray.indexing module."""
+
+import tempfile
+from pathlib import Path
+
+import lance
+import lance_ray as lr
+import pandas as pd
+import pytest
+import ray
+from packaging import version
+
+
+def check_lance_version_compatibility():
+    """Check if lance version supports distributed indexing."""
+    try:
+        lance_version = version.parse(lance.__version__)
+        min_required_version = version.parse("0.36.0")
+        return lance_version >= min_required_version
+    except (AttributeError, Exception):
+        return False
+
+
+# Skip all distributed indexing tests if lance version is incompatible
+pytestmark = pytest.mark.skipif(
+    not check_lance_version_compatibility(),
+    reason="Distributed indexing requires pylance >= 0.36.0. Current version: {}".format(
+        getattr(lance, '__version__', 'unknown')
+    )
+)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ray_context():
+    """Initialize Ray for testing."""
+    # Shutdown Ray if it's already running to avoid conflicts
+    if ray.is_initialized():
+        ray.shutdown()
+
+    # Initialize Ray with minimal configuration
+    ray.init(local_mode=False, ignore_reinit_error=True)
+    yield
+
+    # Clean shutdown
+    if ray.is_initialized():
+        ray.shutdown()
+
+
+@pytest.fixture
+def text_data():
+    """Create sample text data for indexing tests."""
+    return pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 5, 6, 7, 8],
+            "text": [
+                "The quick brown fox jumps over the lazy dog",
+                "Python is a powerful programming language",
+                "Machine learning algorithms are fascinating",
+                "Data science requires statistical knowledge",
+                "Natural language processing uses text analysis",
+                "Distributed computing scales horizontally",
+                "Ray framework enables parallel processing",
+                "Lance format provides efficient storage",
+            ],
+            "category": ["animals", "tech", "ml", "data", "nlp", "distributed", "ray", "storage"],
+        }
+    )
+
+
+@pytest.fixture
+def temp_dir():
+    """Create a temporary directory for testing."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield temp_dir
+
+
+@pytest.fixture
+def text_dataset(text_data):
+    """Create a Ray Dataset from text data."""
+    return ray.data.from_pandas(text_data)
+
+
+@pytest.fixture
+def multi_fragment_lance_dataset(text_dataset, temp_dir):
+    """Create a Lance dataset with multiple fragments for testing."""
+    path = Path(temp_dir) / "multi_fragment_text.lance"
+    # Create dataset with multiple fragments (2 rows per fragment)
+    lr.write_lance(text_dataset, str(path), max_rows_per_file=2)
+    return str(path)
+
+
+def generate_multi_fragment_dataset(tmp_path, num_fragments=4, rows_per_fragment=250):
+    """Generate a test dataset with multiple fragments."""
+    all_data = []
+    for frag_idx in range(num_fragments):
+        for row_idx in range(rows_per_fragment):
+            row_id = frag_idx * rows_per_fragment + row_idx
+            all_data.append({
+                "id": row_id,
+                "text": f"This is test document {row_id} with some sample text content for fragment {frag_idx}",
+                "fragment_id": frag_idx,
+            })
+
+    df = pd.DataFrame(all_data)
+    dataset = ray.data.from_pandas(df)
+
+    path = Path(tmp_path) / "large_multi_fragment.lance"
+    lr.write_lance(dataset, str(path), max_rows_per_file=rows_per_fragment)
+
+    return lance.dataset(str(path))
+
+
+class TestDistributedIndexing:
+    """Test cases for distributed indexing functionality."""
+
+    def test_build_distributed_fts_index_basic(self, multi_fragment_lance_dataset):
+        """Test basic distributed FTS index building."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        # Build distributed index
+        updated_dataset = lr.create_scalar_index(
+            dataset=dataset_uri,
+            column="text",
+            index_type="INVERTED",
+            num_workers=2,
+        )
+
+        # Verify the index was created
+        indices = updated_dataset.list_indices()
+        assert len(indices) > 0, "No indices found after building"
+
+        # Find our index
+        text_index = None
+        for idx in indices:
+            if "text" in idx["name"]:
+                text_index = idx
+                break
+
+        assert text_index is not None, "Text index not found"
+        assert text_index["type"] == "Inverted", f"Expected Inverted index, got {text_index['type']}"
+
+    def test_build_distributed_fts_index_with_name(self, multi_fragment_lance_dataset):
+        """Test building distributed index with custom name."""
+        dataset_uri = multi_fragment_lance_dataset
+        custom_name = "custom_text_index"
+
+        # Build distributed index with custom name
+        updated_dataset = lr.create_scalar_index(
+            dataset=dataset_uri,
+            column="text",
+            index_type="INVERTED",
+            name=custom_name,
+            num_workers=2,
+        )
+
+        # Verify the index was created with correct name
+        indices = updated_dataset.list_indices()
+        index_names = [idx["name"] for idx in indices]
+        assert custom_name in index_names, f"Custom index name '{custom_name}' not found in {index_names}"
+
+    def test_build_distributed_fts_index_search_functionality(self, multi_fragment_lance_dataset):
+        """Test that the built index actually works for searching."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        # Build distributed index
+        updated_dataset = lr.create_scalar_index(
+            dataset=dataset_uri,
+            column="text",
+            index_type="INVERTED",
+            num_workers=2,
+        )
+
+        # Test full-text search functionality
+        search_term = "Python"
+        results = updated_dataset.scanner(
+            full_text_query=search_term,
+            columns=["id", "text"],
+        ).to_table()
+
+        # Should find at least one result containing "Python"
+        assert results.num_rows > 0, f"No results found for search term '{search_term}'"
+
+        # Verify results contain the search term
+        text_results = results.column("text").to_pylist()
+        assert any(search_term in text for text in text_results), "Search results don't contain the search term"
+
+    def test_build_distributed_fts_index_fts_type(self, multi_fragment_lance_dataset):
+        """Test building distributed FTS index."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        # Build distributed FTS index
+        updated_dataset = lr.create_scalar_index(
+            dataset=dataset_uri,
+            column="text",
+            index_type="INVERTED",
+            num_workers=2,
+        )
+
+        # Verify the index was created
+        indices = updated_dataset.list_indices()
+        assert len(indices) > 0, "No indices found after building"
+
+    def test_build_distributed_index_large_dataset(self, temp_dir):
+        """Test distributed indexing on a larger dataset with multiple fragments."""
+        # Generate larger dataset
+        dataset = generate_multi_fragment_dataset(
+            temp_dir, num_fragments=4, rows_per_fragment=50
+        )
+
+        # Build distributed index
+        updated_dataset = lr.create_scalar_index(
+            dataset=dataset,
+            column="text",
+            index_type="INVERTED",
+            num_workers=4,
+        )
+
+        # Verify the index was created
+        indices = updated_dataset.list_indices()
+        assert len(indices) > 0, "No indices found after building"
+
+        # Test search functionality
+        search_term = "test"
+        results = updated_dataset.scanner(
+            full_text_query=search_term,
+            columns=["id", "text"],
+        ).to_table()
+
+        assert results.num_rows > 0, f"No results found for search term '{search_term}'"
+
+    def test_build_distributed_index_invalid_column(self, multi_fragment_lance_dataset):
+        """Test error handling for invalid column."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        with pytest.raises(ValueError, match="Column 'nonexistent' not found"):
+            lr.create_scalar_index(
+                dataset=dataset_uri,
+                column="nonexistent",
+                index_type="INVERTED",
+                num_workers=2,
+            )
+
+    def test_build_distributed_index_invalid_index_type(self, multi_fragment_lance_dataset):
+        """Test error handling for invalid index type."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        with pytest.raises(ValueError, match="Index type must be 'INVERTED' or 'FTS'"):
+            lr.create_scalar_index(
+                dataset=dataset_uri,
+                column="text",
+                index_type="INVALID",
+                num_workers=2,
+            )
+
+    def test_build_distributed_index_invalid_num_workers(self, multi_fragment_lance_dataset):
+        """Test error handling for invalid num_workers."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        with pytest.raises(ValueError, match="num_workers must be positive"):
+            lr.create_scalar_index(
+                dataset=dataset_uri,
+                column="text",
+                index_type="INVERTED",
+                num_workers=0,
+            )
+
+    def test_build_distributed_index_empty_column(self, multi_fragment_lance_dataset):
+        """Test error handling for empty column name."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        with pytest.raises(ValueError, match="Column name cannot be empty"):
+            lr.create_scalar_index(
+                dataset=dataset_uri,
+                column="",
+                index_type="INVERTED",
+                num_workers=2,
+            )
+
+    def test_build_distributed_index_non_string_column(self, temp_dir):
+        """Test error handling for non-string column."""
+        # Create dataset with non-string column
+        data = pd.DataFrame({
+            "id": [1, 2, 3, 4],
+            "numeric_col": [10, 20, 30, 40],
+            "text": ["text1", "text2", "text3", "text4"],
+        })
+        dataset = ray.data.from_pandas(data)
+        path = Path(temp_dir) / "non_string_test.lance"
+        lr.write_lance(dataset, str(path), max_rows_per_file=2)
+
+        with pytest.raises(TypeError, match="must be string type"):
+            lr.create_scalar_index(
+                dataset=str(path),
+                column="numeric_col",
+                index_type="INVERTED",
+                num_workers=2,
+            )
+
+    def test_build_distributed_index_with_ray_remote_args(self, multi_fragment_lance_dataset):
+        """Test building distributed index with Ray options."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        # Build distributed index with Ray options
+        updated_dataset = lr.create_scalar_index(
+            dataset=dataset_uri,
+            column="text",
+            index_type="INVERTED",
+            num_workers=2,
+            ray_remote_args={"num_cpus": 1},
+        )
+
+        # Verify the index was created
+        indices = updated_dataset.list_indices()
+        assert len(indices) > 0, "No indices found after building"
+
+    def test_build_distributed_index_with_storage_options(self, multi_fragment_lance_dataset):
+        """Test building distributed index with storage options."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        # Build distributed index with storage options
+        updated_dataset = lr.create_scalar_index(
+            dataset=dataset_uri,
+            column="text",
+            index_type="INVERTED",
+            num_workers=2,
+            storage_options={},  # Empty storage options should work
+        )
+
+        # Verify the index was created
+        indices = updated_dataset.list_indices()
+        assert len(indices) > 0, "No indices found after building"
+
+    def test_build_distributed_index_with_kwargs(self, multi_fragment_lance_dataset):
+        """Test building distributed index with additional kwargs."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        # Build distributed index with additional kwargs
+        updated_dataset = lr.create_scalar_index(
+            dataset=dataset_uri,
+            column="text",
+            index_type="INVERTED",
+            num_workers=2,
+            remove_stop_words=False,  # Additional kwarg for create_scalar_index
+        )
+
+        # Verify the index was created
+        indices = updated_dataset.list_indices()
+        assert len(indices) > 0, "No indices found after building"
+
+    def test_build_distributed_index_dataset_object(self, multi_fragment_lance_dataset):
+        """Test building distributed index with Lance dataset object instead of URI."""
+        dataset = lance.dataset(multi_fragment_lance_dataset)
+
+        # Build distributed index using dataset object
+        updated_dataset = lr.create_scalar_index(
+            dataset=dataset,
+            column="text",
+            index_type="INVERTED",
+            num_workers=2,
+        )
+
+        # Verify the index was created
+        indices = updated_dataset.list_indices()
+        assert len(indices) > 0, "No indices found after building"
+
+    def test_build_distributed_index_auto_adjust_workers(self, temp_dir):
+        """Test that num_workers is automatically adjusted if it exceeds fragment count."""
+        # Create dataset with only 2 fragments
+        data = pd.DataFrame({
+            "id": [1, 2, 3, 4],
+            "text": ["text1", "text2", "text3", "text4"],
+        })
+        dataset = ray.data.from_pandas(data)
+        path = Path(temp_dir) / "small_dataset.lance"
+        lr.write_lance(dataset, str(path), max_rows_per_file=2)
+
+        # Request more workers than fragments
+        updated_dataset = lr.create_scalar_index(
+            dataset=str(path),
+            column="text",
+            index_type="INVERTED",
+            num_workers=10,  # More than the 2 fragments
+        )
+
+        # Should still work and create the index
+        indices = updated_dataset.list_indices()
+        assert len(indices) > 0, "No indices found after building"
+
+
+class TestIndexNameGeneration:
+    """Test cases for index name generation functionality."""
+
+    def test_generate_default_index_name_basic(self):
+        """Test basic index name generation."""
+        from lance_ray.index import generate_default_index_name
+
+        name = generate_default_index_name("text", "INVERTED")
+        assert name == "text_inverted_idx"
+
+    def test_generate_default_index_name_special_chars(self):
+        """Test index name generation with special characters."""
+        from lance_ray.index import generate_default_index_name
+
+        name = generate_default_index_name("text-column.name", "FTS")
+        assert name == "text_column_name_fts_idx"
+
+    def test_generate_default_index_name_empty_column(self):
+        """Test index name generation with empty column name."""
+        from lance_ray.index import generate_default_index_name
+
+        name = generate_default_index_name("", "INVERTED")
+        assert name == "column_inverted_idx"
+
+    def test_generate_default_index_name_numeric_start(self):
+        """Test index name generation with column starting with number."""
+        from lance_ray.index import generate_default_index_name
+
+        name = generate_default_index_name("123column", "INVERTED")
+        assert name == "column_inverted_idx"
+
+    def test_generate_default_index_name_with_dataset_conflict(self, multi_fragment_lance_dataset):
+        """Test index name generation with existing index conflicts."""
+        from lance_ray.index import generate_default_index_name
+
+        dataset = lance.dataset(multi_fragment_lance_dataset)
+
+        # First call should return base name
+        name1 = generate_default_index_name("text", "INVERTED", dataset)
+        assert name1 == "text_inverted_idx"
+
+        # Mock existing indices by creating a dataset with an index
+        # (This is a simplified test - in real scenario we'd have actual indices)
+        name2 = generate_default_index_name("text", "INVERTED", dataset)
+        # Should still return base name since no actual conflicts exist
+        assert name2 == "text_inverted_idx"
+
+class TestDistributedIndexingNewAPI:
+    """Test cases for the new distributed indexing API from PR #4578."""
+
+    def test_distributed_fts_index_new_api(self, temp_dir):
+        """
+        Test distributed FTS index building using the new API from PR #4578.
+        This test demonstrates the new workflow with execute_uncommitted() and merge_index_metadata().
+        """
+        # Generate test dataset with multiple fragments
+        ds = generate_multi_fragment_dataset(
+            temp_dir, num_fragments=4, rows_per_fragment=250
+        )
+
+        # Test with the new distributed index building function
+        updated_dataset = lr.create_scalar_index(
+            dataset=ds,
+            column="text",
+            index_type="INVERTED",
+            name="new_api_test_idx",
+            num_workers=2,
+            remove_stop_words=False,
+        )
+
+        # Verify the index was created
+        indices = updated_dataset.list_indices()
+        assert len(indices) > 0, "No indices found after distributed index creation"
+
+        # Find our index
+        our_index = None
+        for idx in indices:
+            if idx["name"] == "new_api_test_idx":
+                our_index = idx
+                break
+
+        assert our_index is not None, "Index 'new_api_test_idx' not found in indices list"
+        assert our_index["type"] == "Inverted", (
+            f"Expected Inverted index, got {our_index['type']}"
+        )
+
+        # Test that the index works for searching
+        sample_data = updated_dataset.take([0], columns=["text"])
+        sample_text = sample_data.column(0)[0].as_py()
+        search_word = sample_text.split()[0] if sample_text.split() else "test"
+
+        # Perform a full-text search to verify the index works
+        results = updated_dataset.scanner(
+            full_text_query=search_word,
+            columns=["id", "text"],
+        ).to_table()
+
+        print(f"Search for '{search_word}' returned {results.num_rows} results")
+        assert results.num_rows > 0, f"No results found for search term '{search_word}'"
+
+
+
+    def test_distributed_index_with_fragment_uuid(self, temp_dir):
+        """
+        Test distributed index building with explicit fragment UUID handling.
+        This tests the new fragment_uuid parameter from PR #4578.
+        """
+        # Generate test dataset
+        ds = generate_multi_fragment_dataset(
+            temp_dir, num_fragments=3, rows_per_fragment=100
+        )
+
+        # Test with explicit fragment UUID handling
+        updated_dataset = lr.create_scalar_index(
+            dataset=ds,
+            column="text",
+            index_type="INVERTED",
+            name="fragment_uuid_test_idx",
+            num_workers=2,
+        )
+
+        # Verify the index was created
+        indices = updated_dataset.list_indices()
+        assert len(indices) > 0, "No indices found after index creation"
+
+        # Find our index
+        our_index = None
+        for idx in indices:
+            if idx["name"] == "fragment_uuid_test_idx":
+                our_index = idx
+                break
+
+        assert our_index is not None, "Index 'fragment_uuid_test_idx' not found"
+        assert our_index["type"] == "Inverted", (
+            f"Expected Inverted index, got {our_index['type']}"
+        )
+
+    def test_distributed_index_error_handling_new_api(self, temp_dir):
+        """
+        Test error handling in the new distributed indexing API.
+        """
+        # Generate test dataset
+        ds = generate_multi_fragment_dataset(
+            temp_dir, num_fragments=2, rows_per_fragment=50
+        )
+
+        # Test with invalid parameters that should be caught by the new API
+        with pytest.raises(ValueError, match="Column name cannot be empty"):
+            lr.create_scalar_index(
+                dataset=ds,
+                column="",
+                index_type="INVERTED",
+                num_workers=2,
+            )
+
+        # Test with invalid index type
+        with pytest.raises(ValueError, match="Index type must be 'INVERTED' or 'FTS'"):
+            lr.create_scalar_index(
+                dataset=ds,
+                column="text",
+                index_type="INVALID_TYPE",
+                num_workers=2,
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -1741,7 +1741,7 @@ wheels = [
 
 [[package]]
 name = "pylance"
-version = "0.30.0"
+version = "0.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1749,13 +1749,13 @@ dependencies = [
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/9c/1f94c6f30bd6cea63cd009ad447af3603ab03d21984096936bd14d3eeedf/pylance-0.30.0-cp39-abi3-macosx_10_15_x86_64.whl", hash = "sha256:b64ae00a69a1d463d121198220df46c3dcf5672c0c02d81a9fc74c73b8725636", size = 36724948, upload-time = "2025-06-19T21:03:03.504Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/55/3e0c978c1ae20e33f3aa08a31c8467c4d96d1a8339c187ee190acb4604a2/pylance-0.30.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:b3378e9146ece409b6073ea1524fd45b8dcde396b8dfeca63a9909817dd4179d", size = 33644109, upload-time = "2025-06-19T20:46:29.488Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/b8/0995986cd48a0dd5324af8f9104cfada4dc1b34ea42dffe9d18167b4e101/pylance-0.30.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e60dcdb62fc8d2cc130f89a37f989c2af43e007f6d652044d64ff913efa73619", size = 35499113, upload-time = "2025-06-19T20:45:25.004Z" },
-    { url = "https://files.pythonhosted.org/packages/81/6a/d7bd49e1ce736dabc433bbab34a254031c45d7205ed2ac21d07fa4b82e75/pylance-0.30.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3adbde0b2b7a02e2d1fbf751e38d614d77527f670bcf81e79ba5db3fb59312f0", size = 38562715, upload-time = "2025-06-19T20:48:55.432Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/d9/b9f8b295d5409873393a79eab5131898fcdbc54c21b5929a4e1105f5e828/pylance-0.30.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f5a946bb96a3b3219e4f04bc4d544dd74c97a9d060b7236574d30cc3e44b502a", size = 35516338, upload-time = "2025-06-19T20:44:54.914Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/1a/b7a340aeabdb55c9e9632c8c00401fca5a6b640839afaac6e960f154664c/pylance-0.30.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:8644ac7f02c8ff2d73db084c670bbd5de7e9e59fea566fd71bd4e1a98f889cd0", size = 38494798, upload-time = "2025-06-19T20:49:35.4Z" },
-    { url = "https://files.pythonhosted.org/packages/16/ba/ddc813f2be56bab55d8c570aea1cd1a74741aca8b95f4e92d1913775f47f/pylance-0.30.0-cp39-abi3-win_amd64.whl", hash = "sha256:72b4fdb24152148970e4dbbcca2ab3e1a02d63afcc9bceef14474c536c5b978d", size = 39658973, upload-time = "2025-06-19T21:05:33.786Z" },
+    { url = "https://files.pythonhosted.org/packages/09/13/f7f029d12a3dfdc9f3059d77b3999d40f9cc064ba85fef885a08bf65dcb2/pylance-0.36.0-cp39-abi3-macosx_10_15_x86_64.whl", hash = "sha256:160ed088dc5fb63a71c8c96640d43ea58464f64bca8aa23b0337b1a96fd47b79", size = 43403867, upload-time = "2025-09-12T20:29:25.507Z" },
+    { url = "https://files.pythonhosted.org/packages/95/95/defad18786260653b33d5ef8223736c0e481861c8d33311756bd471468ad/pylance-0.36.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ce43ad002b4e67ffb1a33925d05d472bbde77c57a5e84aca1728faa9ace0c086", size = 39777498, upload-time = "2025-09-12T20:27:02.906Z" },
+    { url = "https://files.pythonhosted.org/packages/19/33/7080ed4e45648d8c803a49cd5a206eb95176ef9dc06bff26748ec2109c65/pylance-0.36.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ad7b168b0d4b7864be6040bebaf6d9a3959e76a190ff401a84b165b75eade96", size = 41819489, upload-time = "2025-09-12T20:17:06.37Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9a/0c572994d96e03e70481dafb2b062033a9ce24beb5ac6045f00f013ca57c/pylance-0.36.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:353deeb7b19be505db490258b5f2fc897efd4a45255fa0d51455662e01ad59ab", size = 45366480, upload-time = "2025-09-12T20:19:53.924Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/82/a74f0436b6a983c2798d1f44699352cd98c42bc335781ece98a878cf63fb/pylance-0.36.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9cd963fc22257591d1daf281fa2369e05299d78950cb11980aa099d7cbacdf00", size = 41833322, upload-time = "2025-09-12T20:17:40.784Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f2/d28fa3487992c3bd46af6838da13cf9a00be24fcf4cf928f77feec52d8d6/pylance-0.36.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:40117569a87379e08ed12eccac658999158f81df946f2ed02693b77776b57597", size = 45347065, upload-time = "2025-09-12T20:19:26.435Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/ab/e7fc302950f1c6815a6e832d052d0860130374bfe4bd482b075299dc8384/pylance-0.36.0-cp39-abi3-win_amd64.whl", hash = "sha256:a2930738192e5075220bc38c8a58ff4e48a71d53b3ca2a577ffce0318609cac0", size = 46348996, upload-time = "2025-09-12T20:36:04.663Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.0.10"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
@@ -681,9 +681,9 @@ dependencies = [
     { name = "pylance" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/2d/a52a4dfada200cc562e0f9afb3031bfa00231b89a4aaaacee682ffef1ded/lance_namespace-0.0.10.tar.gz", hash = "sha256:2607259d6e649cdd97de2f85d28382734c4fa7532610b19b451dd8363ce0c577", size = 32460, upload-time = "2025-08-30T16:29:52.614Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/02/32f1362be5fd4bf310552326f9948d200a492a7bdbeadf406ec0b895e14a/lance_namespace-0.0.14.tar.gz", hash = "sha256:968db20f31dce71107d01f121610415ea28247303161ac5645346220899be14d", size = 32461, upload-time = "2025-09-02T03:48:40.932Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/ef/aab0b6505ec0acb80c976ace80e4da64aae48a5a694c5839bbada0d9b24a/lance_namespace-0.0.10-py3-none-any.whl", hash = "sha256:b754a89b45e8bd4051b275078b8f98aa7d0dfad6f0f41ef05b2cf217cf2bc604", size = 24305, upload-time = "2025-08-30T16:29:51.575Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/19/d589dcb4d5e85f56417659c97e812afdb8094ce40d57f7a0d8826b299cc4/lance_namespace-0.0.14-py3-none-any.whl", hash = "sha256:905f003f0f0b63a9e02bf5d48f97938c9930ee23c32af568798d5776fb8fc94d", size = 24306, upload-time = "2025-09-02T03:48:40.069Z" },
 ]
 
 [package.optional-dependencies]
@@ -708,7 +708,7 @@ wheels = [
 
 [[package]]
 name = "lance-ray"
-version = "0.0.2"
+version = "0.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "lance-namespace", extra = ["dir"] },
@@ -736,7 +736,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "lance-namespace", extras = ["dir"], specifier = ">=0.0.10" },
+    { name = "lance-namespace", extras = ["dir"], specifier = ">=0.0.14" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },
     { name = "mkdocs-awesome-pages-plugin", marker = "extra == 'docs'", specifier = ">=2.9.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0.0" },


### PR DESCRIPTION
close https://github.com/lancedb/lance-ray/issues/12

### Key Improvements

1. **New Distributed APIs in lance-ray**:
   - `create_scalar_index()` - Distributedly create index index using ray with a single method. Currently only support INVERTED type for FTS index. Other types like Btree shall be supported soon by other contributors.

2. **Three-Phase Workflow**: 
   - **Split and Parallel Phase**: Distribute dataset fragments to different Ray worker nodes, try to balance the fragments based on the number of rows.  Each worker node builds indices for its assigned fragments as a partition.  
   - **Merge Phase**: Collect and merge partition index metadata from all worker nodes by calling the new method `merge_index_metadata` by this https://github.com/lancedb/lance/pull/4578
   - **Commit Phase**: Atomically commit index information to the dataset
